### PR TITLE
fix: Context overwrite

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -26,7 +26,7 @@ export function createMediator <
 
     send: (event, modifier) => {
       if(modifier) {
-        context = freezeCopy(modifier(context))
+        context = freezeCopy({ ...context, ...modifier(context) })
       }
 
       const eventHandlers = handlers.get(event)

--- a/src/mediator.spec.ts
+++ b/src/mediator.spec.ts
@@ -67,5 +67,15 @@ describe('mediator context', () => {
         expect(mediator.off('test', () => {})).toBeUndefined()
       })
     })
+
+    describe('when context is overwrited', () => {
+      it('should preserve the original context', () => {
+        const mediator = createMediator(initial)
+        const expected = { done: true }
+        mediator.send('toggle', (ctx) => ({ done: !ctx.done }))
+        mediator.send('overwrite', () => ({}) as Context)
+        expect(mediator.getContext()).toEqual(expected)
+      })
+    })
   })
 })


### PR DESCRIPTION
# Describe

This fix #7 when is possible overwrite context with an empty object.