### PR TITLE
feature: wildcard listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The mediator use simple strings to identify events, think of it as a unique iden
 Optionally, you can define a type that extends from `string` to represent the events that your mediator has.
 
 ```typescript
-type MyEvents = 'value:change' | 'active:toggle' | 'item:added' | 'item:removed'
+type MyEvents = 'loaded' | 'value:change' | 'item:added' | 'item:removed'
 
 export const myMediator = createMediator<MyContext, MyEvents>(initialContext)
 ```
@@ -98,30 +98,44 @@ To listen to events use the `.on` method
 ```typescript
 import { myMediator, MyContext } from './my-mediator'
 
-function myEventListener(ctx: Readonly<MyContext>) {
+function myEventListener(ctx: Readonly<MyContext>, event: MyEvents) {
   // do what you want
 }
 
-myMediator.on('event-name', myEventListener)
+myMediator.on('loaded', myEventListener)
 ```
 
 If you prefer you could use the type `MediatorEventListener`
 
 ```typescript
 import { MediatorEventListener } from '@ortense/mediator'
-import { myMediator, MyContext } from './my-mediator'
+import { myMediator, MyContext, MyEvents } from './my-mediator'
 
-const myEventListener: MediatorEventListener = (ctx) => {
+const myEventListener: MediatorEventListener<MyContext, MyEvents> = (ctx, event) => {
   // do what you want
 }
 
-myMediator.on('event-name', myEventListener)
+myMediator.on('loaded', myEventListener)
+```
+
+You also use de wildcard `*` to listen all events.
+
+```typescript
+myMediator.on('*', (ctx, event) => console.log(ctx, event))
+```
+
+Wildcard listeners could be useful for debugging, for example logging whenever an event is triggered.
+
+```typescript
+myMediator.on('*', (ctx, event) => {
+  console.log(`Event ${event} change the context to`, ctx)
+})
 ```
 
 To stop use the `.off` method
 
 ```typescript
-myMediator.off('event-name', myEventListener)
+myMediator.off('loaded', myEventListener)
 ```
 
 ### Send events
@@ -131,24 +145,24 @@ To send events use the `.send` method.
 ```typescript
 import { myMediator} from './my-mediator'
 
-myMediator.send('hello-world')
+myMediator.send('loaded')
 ```
 
-All listener functions for the `hello-world` event will be called in the order they were added to the mediator.
+All listener functions for the `loaded` event will be called in the order they were added to the mediator.
 
 The `.send` method could receive a function to modifiy the context:
 
 ```typescript
 import { myMediator, MyContext } from './my-mediator'
 
-function toggleActive(ctx: Readonly<MyContext>) {
+function changeValue(ctx: Readonly<MyContext>) {
   return {
     ...ctx,
-    active: !ctx.active
+    value: 'new value'
   }
 }
 
-myMediator.send('toggle', toggleActive)
+myMediator.send('value:change', changeValue)
 ```
 
 If you prefer you could use the `MediatorContextModifier` type.
@@ -157,12 +171,12 @@ If you prefer you could use the `MediatorContextModifier` type.
 import { MediatorContextModifier } from '@ortense/mediator'
 import { myMediator, MyContext } from './my-mediator'
 
-const toggleActive: MediatorContextModifier<MyContext> = (ctx) => ({
+const changeValue: MediatorContextModifier<MyContext> = (ctx) => ({
   ...ctx,
-  active: !ctx.active
+  value: 'new value'
 })
 
-myMediator.send('toggle', toggleActive)
+myMediator.send('value:change', changeValue)
 ```
 
 Or an inline declaration:
@@ -170,7 +184,7 @@ Or an inline declaration:
 ```typescript
 import { myMediator } from './my-mediator'
 
-myMediator.send('toggle', (ctx) => ({ ...ctx, active: !ctx.active }))
+myMediator.send('value:change', (ctx) => ({ ...ctx, active: 'new value }))
 ```
 
 ### Get current context

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,7 +6,7 @@ export function createMediator <
   Context extends MediatorContext, 
   EventName extends string = string,
 >(initialContext: Context): Mediator<Context, EventName> {
-  const handlers = new Map<string, Array<MediatorEventListener<Context>>>()
+  const handlers = new Map<string, Array<MediatorEventListener<Context, EventName>>>()
   let context = freezeCopy(initialContext)
 
   return {
@@ -29,11 +29,8 @@ export function createMediator <
         context = freezeCopy({ ...context, ...modifier(context) })
       }
 
-      const eventHandlers = handlers.get(event)
-
-      if(eventHandlers !== undefined) {
-        eventHandlers.forEach(fn => fn(context))
-      }
+      handlers.get(event)?.forEach(fn => fn(context, event))
+      handlers.get('*')?.forEach(fn => fn(context, event))
     },
 
     getContext: () => freezeCopy(context),

--- a/src/mediator.spec.ts
+++ b/src/mediator.spec.ts
@@ -4,7 +4,7 @@ import { createMediator } from './factory'
 type Context = { done: boolean }
 const initial = { done: false }
 
-describe('mediator context', () => {
+describe('Mediator', () => {
   describe('when mediator is created', () => {
     it('should not use initial context as reference', () => {
       const mediator = createMediator(initial)
@@ -14,7 +14,7 @@ describe('mediator context', () => {
     })
   })
 
-  describe('dispatch', () => {
+  describe('when send and envent', () => {
     it('it should call event modifier', () => {
       type EventName = 'toggle'
       const mediator = createMediator<Context, EventName>(initial)
@@ -28,6 +28,29 @@ describe('mediator context', () => {
     })
 
     it('it should call event listeners', () => {
+      const mediator = createMediator<Context, 'toggle' | 'done'>({ done: true })
+
+      const listenerOne = vitest.fn()
+      const listenerTwo = vitest.fn()
+      const listenerDone = vitest.fn()
+      
+      mediator.on('toggle', listenerOne)
+      mediator.on('toggle', listenerTwo)
+      mediator.on('done', listenerDone)
+
+      mediator.send('toggle', (ctx: Context) => ({ done: !ctx.done }))
+      mediator.send('done', () => ({ done: true }))
+
+      expect(listenerOne).toHaveBeenCalledTimes(1)
+      expect(listenerOne).toHaveBeenCalledTimes(1)
+      expect(listenerOne).toBeCalledWith({ done: false }, 'toggle')
+      expect(listenerTwo).toBeCalledWith({ done: false }, 'toggle')
+      expect(listenerDone).toBeCalledWith({ done: true }, 'done')
+    })
+  })
+
+  describe('when remove event listener', () => {
+    it('it should call event listeners', () => {
       const mediator = createMediator(initial)
       const toggle = (ctx: Context) => ({ done: !ctx.done })
       const listenerOne = vitest.fn()
@@ -36,29 +59,11 @@ describe('mediator context', () => {
       mediator.on('toggle', listenerOne)
       mediator.on('toggle', listenerTwo)
       mediator.send('toggle', toggle)
+      mediator.off('toggle', listenerTwo)
+      mediator.send('toggle', toggle)
 
-      expect(listenerOne).toHaveBeenCalledTimes(1)
-      expect(listenerOne).toHaveBeenCalledTimes(1)
-      expect(listenerOne).toBeCalledWith({ done: true })
-      expect(listenerTwo).toBeCalledWith({ done: true })
-    })
-
-    describe('when remove event listener', () => {
-      it('it should call event listeners', () => {
-        const mediator = createMediator(initial)
-        const toggle = (ctx: Context) => ({ done: !ctx.done })
-        const listenerOne = vitest.fn()
-        const listenerTwo = vitest.fn()
-        
-        mediator.on('toggle', listenerOne)
-        mediator.on('toggle', listenerTwo)
-        mediator.send('toggle', toggle)
-        mediator.off('toggle', listenerTwo)
-        mediator.send('toggle', toggle)
-  
-        expect(listenerOne).toHaveBeenCalledTimes(2)
-        expect(listenerTwo).toHaveBeenCalledTimes(1)
-      })
+      expect(listenerOne).toHaveBeenCalledTimes(2)
+      expect(listenerTwo).toHaveBeenCalledTimes(1)
     })
 
     describe('when try remove an invalid listener', () => {
@@ -67,14 +72,44 @@ describe('mediator context', () => {
         expect(mediator.off('test', () => {})).toBeUndefined()
       })
     })
+  })
 
-    describe('when context is overwrited', () => {
-      it('should preserve the original context', () => {
-        const mediator = createMediator(initial)
-        const expected = { done: true }
-        mediator.send('toggle', (ctx) => ({ done: !ctx.done }))
-        mediator.send('overwrite', () => ({}) as Context)
-        expect(mediator.getContext()).toEqual(expected)
+  describe('when context is overwrited', () => {
+    it('should preserve the original context', () => {
+      const mediator = createMediator(initial)
+      const expected = { done: true }
+      mediator.send('toggle', (ctx) => ({ done: !ctx.done }))
+      mediator.send('overwrite', () => ({}) as Context)
+      expect(mediator.getContext()).toEqual(expected)
+    })
+  })
+
+  describe('when using wildcard', () => {
+    it('should execute the wildcard listener for any event', () => {
+      const mediator = createMediator<Context, 'one' | 'two'>(initial)
+      const listener = vitest.fn()
+
+      mediator.on('*', listener)
+      mediator.send('one')
+      mediator.send('two')
+
+      expect(listener).toBeCalledTimes(2)
+      expect(listener).toHaveBeenNthCalledWith(1, initial, 'one')
+      expect(listener).toHaveBeenNthCalledWith(2, initial, 'two')
+    })
+
+    describe('when remove wildcard listener', () => {
+      it('should stop execute listener', () => {
+        const mediator = createMediator<Context, 'one' | 'two'>(initial)
+        const listener = vitest.fn()
+
+        mediator.on('*', listener)
+        mediator.send('one')
+        mediator.off('*', listener)
+        mediator.send('two')
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(listener).toHaveBeenNthCalledWith(1, initial, 'one')
       })
     })
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,12 +8,14 @@ export type Dictionary = { [member: string]: Value }
 
 export type MediatorContext = Dictionary
 
-export type MediatorEventListener<T extends MediatorContext> = (ctx: Readonly<T>) => void
+export type WildcardEvent = '*'
+
+export type MediatorEventListener<T extends MediatorContext, EventName extends string> = (ctx: Readonly<T>, eventName: EventName) => void
 export type MediatorContextModifier<T extends MediatorContext> = (ctx: Readonly<T>) => T
 
 export type Mediator<T extends MediatorContext, EventName extends string> = {
-  on(event: EventName, listener: MediatorEventListener<T>): void,
-  off(event: EventName, listener: MediatorEventListener<T>): void,
+  on(event: WildcardEvent | EventName, listener: MediatorEventListener<T, EventName>): void,
+  off(event: WildcardEvent | EventName, listener: MediatorEventListener<T, EventName>): void,
   send(event: EventName, modifier?: MediatorContextModifier<T>): void,
   getContext(): Readonly<T>
 }


### PR DESCRIPTION
# Description

This PR add a new feature `wildcard listener` allow to use the event name `*` to listen all events triggered.

```typescript
myMediator.on('*', (ctx, event) => {
  console.log(`Event ${event} change the context to`, ctx)
})
```

resolve #12 