### PR TITLE
refactor: replace `JSON.parse` with `structureClone` do clone context

### DIFF
--- a/.changeset/chilled-boxes-walk.md
+++ b/.changeset/chilled-boxes-walk.md
@@ -1,0 +1,5 @@
+---
+"@ortense/mediator": minor
+---
+
+replace `JSON.parse` with `structureClone` do clone context

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,7 +1,5 @@
 import { Mediator, MediatorContext, MediatorEventListener } from './types.ts'
 
-const freezeCopy = <T>(ctx: T): T => Object.freeze(JSON.parse(JSON.stringify(ctx)))
-
 /**
  * Creates a Mediator instance with a specific initial context.
  * @function createMediator
@@ -25,7 +23,7 @@ export function createMediator <
   EventName extends string = string,
 >(initialContext: Context): Mediator<Context, EventName> {
   const handlers = new Map<string, Array<MediatorEventListener<Context, EventName>>>()
-  let context = freezeCopy(initialContext)
+  let context = structuredClone(initialContext)
 
   return {
     on: (event, listener) => {
@@ -44,13 +42,13 @@ export function createMediator <
 
     send: (event, modifier) => {
       if(modifier) {
-        context = freezeCopy({ ...context, ...modifier(context) })
+        context = structuredClone({ ...context, ...modifier(context) })
       }
 
       handlers.get(event)?.forEach(fn => fn(context, event))
       handlers.get('*')?.forEach(fn => fn(context, event))
     },
 
-    getContext: () => freezeCopy(context),
+    getContext: () => structuredClone(context),
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type MediatorContextModifier<Context extends MediatorContext> = (ctx: Rea
  * @template Context - The type of the MediatorContext.
  * @template EventName - The type of the event names.
  */
-export interface Mediator<Context extends MediatorContext, EventName extends string> {
+export type Mediator<Context extends MediatorContext, EventName extends string> = {
   /**
    * Adds an event listener to the Mediator.
    * @method


### PR DESCRIPTION
# Description

Replace `JSON.parse` with `structureClone` do clone context

## References

- [MDN - structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
- [Can I use ... structureClone](https://caniuse.com/?search=structuredClone)