### PR TITLE
feat: Accept context modifier with at least one property of context

### DIFF
--- a/.changeset/slow-ligers-protect.md
+++ b/.changeset/slow-ligers-protect.md
@@ -1,0 +1,5 @@
+---
+"@ortense/mediator": minor
+---
+
+Accept context modifier with at least one property of context

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ import { myMediator, MyContext } from './my-mediator'
 
 function changeValue(ctx: Readonly<MyContext>) {
   return {
-    ...ctx,
     value: 'new value'
   }
 }
@@ -176,7 +175,6 @@ import { MediatorContextModifier } from '@ortense/mediator'
 import { myMediator, MyContext } from './my-mediator'
 
 const changeValue: MediatorContextModifier<MyContext> = (ctx) => ({
-  ...ctx,
   value: 'new value'
 })
 

--- a/src/mediator.spec.ts
+++ b/src/mediator.spec.ts
@@ -1,7 +1,7 @@
 import { vitest, describe, it, expect } from 'vitest'
 import { createMediator } from './factory'
 
-type Context = { done: boolean }
+type Context = { done: boolean, message?: string }
 const initial = { done: false }
 
 describe('Mediator', () => {
@@ -46,6 +46,17 @@ describe('Mediator', () => {
       expect(listenerOne).toBeCalledWith({ done: false }, 'toggle')
       expect(listenerTwo).toBeCalledWith({ done: false }, 'toggle')
       expect(listenerDone).toBeCalledWith({ done: true }, 'done')
+    })
+
+    describe('Require at least one property of Context', () => {
+      it('should increment context with modifier return', () => { 
+        const mediator = createMediator<Context>({ done: true })
+        mediator.send('message', () => ({ message: 'test' }))
+        expect(mediator.getContext()).toEqual({
+          done: true,
+          message: 'test',
+        })
+      })
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,13 @@ export type JSONArray = JSONValue[]
 /** Represents a dictionary (object) with string keys and values of type JSONValue. */
 export type JSONObject = { [member: string]: JSONValue }
 
+export type Y = Partial<{}>
+
+/** Requires at least one property of T. */
+export type AtLeastOneOf<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>>
+}[keyof T]
+
 /** Represents a context for the Mediator, which is a JSON serializable object. */
 export type MediatorContext = JSONObject
 
@@ -20,7 +27,7 @@ export type WildcardEvent = '*'
 export type MediatorEventListener<Context extends MediatorContext, EventName extends string> = (ctx: Readonly<Context>, eventName: EventName) => void
 
 /** Represents a context modifier function for Mediator events. */
-export type MediatorContextModifier<Context extends MediatorContext> = (ctx: Readonly<Context>) => Context
+export type MediatorContextModifier<Context extends MediatorContext> = (ctx: Readonly<Context>) => AtLeastOneOf<Context>
 
 /**
  * @interface Mediator


### PR DESCRIPTION
# Description

Accept context modifier with at least one property of context

## Usage example

```ts
type Context = { done: boolean, message?: string }

it('should increment context with modifier return', () => { 
  const mediator = createMediator<Context>({ done: true })
  mediator.send('message', () => ({ message: 'test' }))
  expect(mediator.getContext()).toEqual({
    done: true,
    message: 'test',
  })
})
```